### PR TITLE
Fix for recent Anki 2.1 versions

### DIFF
--- a/src/build.bat
+++ b/src/build.bat
@@ -11,11 +11,6 @@ echo %VERSION% >%REPO%\VERSION
 fsum -r -jm -md5 -d%REPO% * > checksum.md5
 move checksum.md5 %REPO%\checksum.md5
 
-%ZIP% %REPO%_v%VERSION%_Anki20.zip *.py %REPO%\*
-
 cd %REPO%
 quick_manifest.exe "%NAME%" "%PACKID%" >manifest.json
 %ZIP% ../%REPO%_v%VERSION%_Anki21.ankiaddon *
-
-quick_manifest.exe "%NAME%" "%NAME%" >manifest.json
-%ZIP% ../%REPO%_v%VERSION%_CCBC.adze *

--- a/src/fanfare/const.py
+++ b/src/fanfare/const.py
@@ -21,5 +21,4 @@ PY3 = version.startswith("2.1.")
 MOD_ABS,_ = os.path.split(__file__)
 MOD_DIR = os.path.basename(MOD_ABS)
 ADDON_FOLDER=mw.pm.addonFolder()
-ADDON_TAG='_ankiAO'
-
+ADDON_TAG = os.path.dirname(__file__)

--- a/src/fanfare/const.py
+++ b/src/fanfare/const.py
@@ -4,18 +4,8 @@
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 
 
-#=== CONFIGS ===============================
-
-# For Anki2.0, used to allow the backported addonManager21 to load first
-STARTUP_DELAY = 300 #in ms
-
-#=== END_CONFIGS ===========================
-############################################
-
-import os, re
+import os
 from aqt import mw
-from anki import version
-PY3 = version.startswith("2.1.")
 
 #All for calculating the addon ID and prevent conflicts w/ other similar pathnames on A21
 MOD_ABS,_ = os.path.split(__file__)

--- a/src/fanfare/fanfare.py
+++ b/src/fanfare/fanfare.py
@@ -102,7 +102,7 @@ class Fanfare():
             dmax=self.settings.theme['duration_max']
             dur=max(0,min(dmax,self.fb.audio_duration-self.duration))
             if POINT_VERSION < 17:
-                mw.progress.timer(dur+delay,lambda:playFromText(card.q()),False)
+                mw.progress.timer(dur+delay,lambda:playFromText(card.q()),False,parent=mw)
             return False
         return bool
 
@@ -133,7 +133,7 @@ class Fanfare():
                     self.duration=max(mdur,self.duration//1.4)
             else:
                 self.state=REVIEW
-            mw.progress.timer(self.duration,lambda:self._nextCard(r,_old),False)
+            mw.progress.timer(self.duration,lambda:self._nextCard(r,_old),False,parent=mw)
         else:
             self.state=REVIEW
             return _old(r)

--- a/src/fanfare/fanfare.py
+++ b/src/fanfare/fanfare.py
@@ -170,13 +170,6 @@ class Fanfare():
         msg="""<img src="%s" style="max-width:100%%" /><br>"""%img
         return msg+_old(sch)
 
-
-
-    #Prevents keypress during FX
-    def linkHandler(self, r, url, _old):
-        if not self.locked: return _old(r,url)
-    def keyHandler(self, r, evt, _old): #v2.0
-        if not self.locked: return _old(r,evt)
     def onEnterKey(self, r, _old): #v2.1
         if not self.locked: return _old(r)
 

--- a/src/fanfare/fanfare.py
+++ b/src/fanfare/fanfare.py
@@ -102,7 +102,7 @@ class Fanfare():
             dmax=self.settings.theme['duration_max']
             dur=max(0,min(dmax,self.fb.audio_duration-self.duration))
             if POINT_VERSION < 17:
-                mw.progress.timer(dur+delay,lambda:playFromText(card.q()),False,parent=mw)
+                mw.progress.timer(dur+delay,lambda:playFromText(card.q()),False)
             return False
         return bool
 
@@ -133,7 +133,7 @@ class Fanfare():
                     self.duration=max(mdur,self.duration//1.4)
             else:
                 self.state=REVIEW
-            mw.progress.timer(self.duration,lambda:self._nextCard(r,_old),False,parent=mw)
+            mw.progress.timer(self.duration,lambda:self._nextCard(r,_old),False)
         else:
             self.state=REVIEW
             return _old(r)

--- a/src/fanfare/fanfare.py
+++ b/src/fanfare/fanfare.py
@@ -54,7 +54,8 @@ class Fanfare():
         self.shown=False
 
     def onShowQuestion(self):
-        self.locked=False
+        if not self.state==RELOAD:
+            self.locked=False
 
     def onReset(self):
         if self.state==INTERMISSION:

--- a/src/fanfare/fanfare.py
+++ b/src/fanfare/fanfare.py
@@ -42,10 +42,7 @@ class Fanfare():
         self.limit=random.randint(3,7)
 
     def onProfileLoaded(self):
-        if PY3:
-            self.initConfigurations()
-        else:
-            mw.progress.timer(STARTUP_DELAY,self.initConfigurations,False)
+        self.initConfigurations()
 
     def initConfigurations(self):
         self.settings=Settings()

--- a/src/fanfare/fanfare.py
+++ b/src/fanfare/fanfare.py
@@ -157,8 +157,7 @@ class Fanfare():
             self.recess.start(self.fb.audio_duration)
             return True
 
-
-    def rewards(self, sch, _old):
+    def getRewards(self):
         delay=gap=0
         if self.state != OVERVIEW and self.duration:
             gap=self.settings.theme['delay_loots']
@@ -167,8 +166,8 @@ class Fanfare():
         self.reward.start(delay)
         did=mw.col.decks.selected()
         img=self.reward.getLoots(did)
-        msg="""<img src="%s" style="max-width:100%%" /><br>"""%img
-        return msg+_old(sch)
+        msg="""<img id="fanfare-reward" src="%s" style="max-width:100%%; display: block; margin: 0 auto;" /><br>"""%img
+        return msg
 
     def onEnterKey(self, r, _old): #v2.1
         if not self.locked: return _old(r)

--- a/src/fanfare/fanfare.py
+++ b/src/fanfare/fanfare.py
@@ -124,20 +124,17 @@ class Fanfare():
 
 
     def delayNextCard(self, r, _old):
-        if self.state<=RELOAD:
-            mw.bottomWeb.hide()
-            if self.state==REVIEW and self.checkLimitBreaker():
-                self.state=INTERMISSION
-                if self.duration:
-                    mdur=self.settings.theme['duration_min']
-                    self.duration=max(mdur,self.duration//1.4)
-            else:
-                self.state=REVIEW
-            mw.progress.timer(self.duration,lambda:self._nextCard(r,_old),False)
+        mw.bottomWeb.hide()
+        if self.state==REVIEW and self.checkLimitBreaker():
+            self.state=INTERMISSION
+            if self.duration:
+                mdur=self.settings.theme['duration_min']
+                self.duration=max(mdur,self.duration//1.4)
         else:
             self.state=REVIEW
-            return _old(r)
-
+        mw.progress.timer(self.duration,lambda:self._nextCard(r,_old),False)
+        if self.state>RELOAD:
+            self.state=REVIEW
 
     def _nextCard(self, r, nxCard):
         self.fb.stop()
@@ -147,6 +144,7 @@ class Fanfare():
             mw.bottomWeb.show()
         else:
             self.recess.stop()
+
 
 
     def checkLimitBreaker(self):

--- a/src/fanfare/feedback.py
+++ b/src/fanfare/feedback.py
@@ -16,9 +16,6 @@ from .audFeedback import *
 from .vsFeedback import *
 from .effect import *
 
-from .lib.com.lovac42.anki.version import ANKI21
-
-
 class Feedback():
     audio_duration=0
     failCnt=-1
@@ -26,10 +23,7 @@ class Feedback():
 
     def __init__(self, settings):
         self.settings=settings
-        if ANKI21:
-            self.ch_image=VsFeedback21(settings)
-        else: 
-            self.ch_image=VsFeedback(settings)
+        self.ch_image=VsFeedback21(settings)
         self.ch_audio=AudFeedback(settings)
 
         self.lapseFx=Effects('lapse', settings)

--- a/src/fanfare/lib/com/lovac42/anki/version.py
+++ b/src/fanfare/lib/com/lovac42/anki/version.py
@@ -5,17 +5,11 @@
 
 from anki import version
 
-ANKI20 = version.startswith("2.0.")
-
-CCBC = version.endswith("ccbc")
-
-ANKI21 = not CCBC and version.startswith("2.1.")
-
-VERSION = version.split('_')[0] #rm ccbc
+VERSION = version.split('_')[0]
 m,n,p = VERSION.split('.')
 
 MAJOR_VERSION = int(m)
 MINOR_VERSION = int(n)
 PATCH_VERSION = int(p)
-POINT_VERSION = 0 if ANKI20 else PATCH_VERSION
+POINT_VERSION = PATCH_VERSION
 

--- a/src/fanfare/loots.py
+++ b/src/fanfare/loots.py
@@ -13,7 +13,6 @@ import random, os, re
 from .const import *
 from .utils import *
 from .effect import Effects
-from .lib.com.lovac42.anki.version import ANKI21
 
 
 class Loots(Effects):
@@ -98,8 +97,6 @@ class Reward(Loots):
 
 
 class Intermission(Loots):
-    CSS = None if ANKI21 else mw.sharedCSS
-
     def _linkHandler(self, url):
         if url=='refresh':
             mw.delayedMaybeReset()
@@ -110,12 +107,9 @@ class Intermission(Loots):
         mw.web.eval("$('#intermission').css('display','')")
 
     def setLinkHandler(self):
-        if ANKI21:
-            mw.web.resetHandlers()
-            mw.web.onBridgeCmd = lambda url: self._linkHandler(url)
-            return 'pycmd'
-        mw.web.setLinkHandler(lambda url: self._linkHandler(url))
-        return 'py.link'
+        mw.web.resetHandlers()
+        mw.web.onBridgeCmd = lambda url: self._linkHandler(url)
+        return 'pycmd'
 
     def start(self, delay=0):
         mw.requireReset(True)
@@ -136,6 +130,6 @@ Resume Now</button></td></tr></table><br><br>
 onclick="%s('replay');return false;" />
 %s</center></div>"""%(cmd,img,cmd,msg)
 
-        mw.web.stdHtml(html, css=self.CSS)
+        mw.web.stdHtml(html)
         mw.bottomWeb.hide()
         mw.web.setFocus()

--- a/src/fanfare/loots.py
+++ b/src/fanfare/loots.py
@@ -31,7 +31,7 @@ class Loots(Effects):
 
     def start(self, delay=0):
         if self.timer: self.timer.stop()
-        self.timer=mw.progress.timer(delay+200,self.replay,False,parent=mw)
+        self.timer=mw.progress.timer(delay+200,self.replay,False)
 
     def replay(self):
         au=self.getAudio()

--- a/src/fanfare/loots.py
+++ b/src/fanfare/loots.py
@@ -91,7 +91,8 @@ class Reward(Loots):
             auName=self.arr_sounds[a]
             auPath=os.path.join(self.ADIR,self.arr_sounds[a])
             self.sound=(a,auName,auPath)
-        return img
+        # we need to construct an absolute link to display in the congrats screen
+        return f"http://127.0.0.1:{mw.mediaServer.getPort()}/{img}"
 
 
 class Intermission(Loots):

--- a/src/fanfare/loots.py
+++ b/src/fanfare/loots.py
@@ -31,7 +31,7 @@ class Loots(Effects):
 
     def start(self, delay=0):
         if self.timer: self.timer.stop()
-        self.timer=mw.progress.timer(delay+200,self.replay,False)
+        self.timer=mw.progress.timer(delay+200,self.replay,False,parent=mw)
 
     def replay(self):
         au=self.getAudio()

--- a/src/fanfare/main.py
+++ b/src/fanfare/main.py
@@ -15,9 +15,27 @@ from .fanfare import *
 
 from .lib.com.lovac42.anki.version import PATCH_VERSION
 
+from aqt.gui_hooks import webview_did_receive_js_message
+
 
 fan=Fanfare()
 
+def linkHandler(handled, message, context):
+    if message == 'refresh':
+        mw.web.page().runJavaScript("""
+document.getElementById("intermission").style.display = 'none';
+document.getElementById("qa").style.display = 'block';
+""")
+        return (True, None)
+    elif message == 'replay':
+        fan.recess.replay()
+        return (True, None)
+    elif not fan.locked:
+        return handled
+    else:
+        return (True, None)
+
+webview_did_receive_js_message.append(linkHandler)
 
 ##################################################
 # Monkey Patches - adds delay for animation smoothness

--- a/src/fanfare/main.py
+++ b/src/fanfare/main.py
@@ -13,7 +13,7 @@ import anki.sched
 from .const import *
 from .fanfare import *
 
-from .lib.com.lovac42.anki.version import ANKI21, CCBC, PATCH_VERSION
+from .lib.com.lovac42.anki.version import PATCH_VERSION
 
 
 fan=Fanfare()
@@ -32,17 +32,11 @@ Reviewer.autoplay = wrap(Reviewer.autoplay, fan.autoplayOnQ, "around")
 
 
 #Rewards
-anki.sched.Scheduler.finishedMsg = wrap(anki.sched.Scheduler.finishedMsg, fan.rewards, 'around')
-if ANKI21 or CCBC:
-    import anki.schedv2
-    anki.schedv2.Scheduler.finishedMsg = wrap(anki.schedv2.Scheduler.finishedMsg, fan.rewards, 'around')
+import anki.schedv2
+anki.schedv2.Scheduler.finishedMsg = wrap(anki.schedv2.Scheduler.finishedMsg, fan.rewards, 'around')
 
-if ANKI21:
-    #Disables keys during fx
-    Reviewer.onEnterKey = wrap(Reviewer.onEnterKey, fan.onEnterKey, "around")
-else:
-    Reviewer._keyHandler = wrap(Reviewer._keyHandler, fan.keyHandler, "around")
-    Reviewer._linkHandler = wrap(Reviewer._linkHandler, fan.linkHandler, "around")
+#Disables keys during fx
+Reviewer.onEnterKey = wrap(Reviewer.onEnterKey, fan.onEnterKey, "around")
 
 
 ################################################################
@@ -69,14 +63,13 @@ def _redirectWebExportsNew(path, _old):
         return redirected
     return _old(path)
 
-if ANKI21:
-    mw.addonManager.setWebExports(__name__, r"user_files/.*")
-    if PATCH_VERSION >= 50:
-        from aqt import mediasrv
-        mediasrv._extract_addon_request = wrap(mediasrv._extract_addon_request, _redirectWebExportsNew, 'around')
-    elif PATCH_VERSION >= 28:
-        from aqt import mediasrv
-        mediasrv._redirectWebExports = wrap(mediasrv._redirectWebExports, _redirectWebExportsNew, 'around')
-    else:
-        from aqt.mediasrv import RequestHandler
-        RequestHandler._redirectWebExports = wrap(RequestHandler._redirectWebExports, _redirectWebExportsOld, 'around')
+mw.addonManager.setWebExports(__name__, r"user_files/.*")
+if PATCH_VERSION >= 50:
+    from aqt import mediasrv
+    mediasrv._extract_addon_request = wrap(mediasrv._extract_addon_request, _redirectWebExportsNew, 'around')
+elif PATCH_VERSION >= 28:
+    from aqt import mediasrv
+    mediasrv._redirectWebExports = wrap(mediasrv._redirectWebExports, _redirectWebExportsNew, 'around')
+else:
+    from aqt.mediasrv import RequestHandler
+    RequestHandler._redirectWebExports = wrap(RequestHandler._redirectWebExports, _redirectWebExportsOld, 'around')

--- a/src/fanfare/settings.py
+++ b/src/fanfare/settings.py
@@ -3,6 +3,7 @@
 # Support: https://github.com/lovac42/Fanfare
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 
+import re
 
 from aqt import mw
 from aqt.qt import *
@@ -11,9 +12,6 @@ from codecs import open
 from anki.utils import json
 import os
 from .utils import *
-
-from .lib.com.lovac42.anki.version import ANKI21, CCBC
-
 
 DEFAULT_THEME_SETTINGS={
     "version":3,
@@ -90,7 +88,7 @@ class Settings:
         self.neutral_img=os.path.join(self.resrc_dir,self.theme['neutral_img'])
 
     def getResourceFolder(self, abs=False):
-        if ANKI21 and not abs:
+        if not abs:
             return os.path.join(ADDON_TAG,MOD_DIR,'user_files',self.theme_dir)
         return os.path.join(MOD_ABS,'user_files',self.theme_dir)
 

--- a/src/fanfare/settings.py
+++ b/src/fanfare/settings.py
@@ -12,6 +12,7 @@ from codecs import open
 from anki.utils import json
 import os
 from .utils import *
+from pathlib import PurePosixPath
 
 DEFAULT_THEME_SETTINGS={
     "version":3,
@@ -89,7 +90,7 @@ class Settings:
 
     def getResourceFolder(self, abs=False):
         if not abs:
-            return os.path.join(ADDON_TAG,MOD_DIR,'user_files',self.theme_dir)
+            return str(PurePosixPath('_addons',MOD_DIR,'user_files',self.theme_dir))
         return os.path.join(MOD_ABS,'user_files',self.theme_dir)
 
     def getPathOf(self, key, abs=False):

--- a/src/fanfare/utils.py
+++ b/src/fanfare/utils.py
@@ -43,17 +43,9 @@ def readJson(path):
         return json.loads(data)
 
 
-
-
-from anki import version
-PY3=version.startswith("2.1.")
-
 #From: https://stackoverflow.com/questions/3232943/
 def nestedUpdate(d, u):
-    if PY3:
-        itm=u.items()
-    else:
-        itm=u.iteritems()
+    itm=u.items()
     for k, v in itm:
         if isinstance(v, collections.Mapping):
             d[k] = nestedUpdate(d.get(k, {}), v)

--- a/src/fanfare/vsFeedback.py
+++ b/src/fanfare/vsFeedback.py
@@ -60,6 +60,7 @@ class VsFeedback21(VsFeedback):
         if self.settings.theme['imgfx'].get('hide_bg',True):
             mw.web.eval("$('#qa').css('visibility','hidden')")
         abs_img=img.replace(ADDON_TAG,ADDON_FOLDER)
+        img=img.replace(ADDON_TAG, f"/_addons")
         lbl=self.label #shows in overview, but not in review
         pos=self.getPos(lbl,abs_img)
 

--- a/src/fanfare/vsFeedback.py
+++ b/src/fanfare/vsFeedback.py
@@ -59,8 +59,7 @@ class VsFeedback21(VsFeedback):
     def show(self, img):
         if self.settings.theme['imgfx'].get('hide_bg',True):
             mw.web.eval("$('#qa').css('visibility','hidden')")
-        abs_img=img.replace(ADDON_TAG,ADDON_FOLDER)
-        img=img.replace(ADDON_TAG, f"/_addons")
+        abs_img=img.replace('_addons',ADDON_FOLDER)
         lbl=self.label #shows in overview, but not in review
         pos=self.getPos(lbl,abs_img)
 

--- a/src/fanfare/vsFeedback.py
+++ b/src/fanfare/vsFeedback.py
@@ -67,18 +67,19 @@ class VsFeedback21(VsFeedback):
 style="width: %d; height: %d; position:fixed; left:%dpx; top: %dpx;" />
 """%(img, lbl.width(),lbl.height(), pos.x(),pos.y())
 
-        mw.web.page().runJavaScript("""
-try{ //reviewer
-  var img=%s
-  document.getElementById("qa").outerHTML+=img
-}catch(err){ //overview
-  document.body.outerHTML+=img
-}"""%json.dumps(html) )
+        mw.reviewer.web.eval("""
+var img=%s;
+try {
+  document.getElementById("qa").insertAdjacentHTML('afterend', img);
+} catch(err) { //overview
+  document.body.insertAdjacentHTML('afterend', img);
+}
+"""%json.dumps(html) )
 
     def close(self):
-        mw.web.page().runJavaScript("""
-try{
-  document.getElementById("visualFeedback21_img").outerHTML=""
-}catch(err){}
+        mw.reviewer.web.eval("""
+try {
+    document.getElementById("visualFeedback21_img").remove();
+} catch(err) {}
 """)
 


### PR DESCRIPTION
This is a quick and dirty fix to make the add-on work on recent Anki versions. Confirmed to work with .49 and .50

At least image display and audio playback work. Some other features may need further changes.

Maybe it's time to drop 2.0 support and simplify the code.

A packaged build of the changes is available here: https://github.com/abdnh/anki-fanfare/releases/tag/v0.2.0
